### PR TITLE
Add .gitattributes to remove unused language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ws -linguist-detectable


### PR DESCRIPTION
This should remove the ' Witcher Script' in the languages detection section.